### PR TITLE
Improve Commands to Receive more flexibility with providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ _testmain.go
 purrgil_*
 docker-compose.yml
 purrgil.yml
+
+mongo

--- a/commands/init.go
+++ b/commands/init.go
@@ -4,19 +4,25 @@ import (
 	"os"
 
 	"github.com/purrgil/purrgil/file"
+	"github.com/purrgil/purrgil/configs"
 	"github.com/purrgil/purrgil/interactiveshell"
 )
 
-func Init(projectName string, projectGithub string) {
+func Init(projectName string, opts configs.InitConfig) {
 	wd, _ := os.Getwd()
 	wdpath := wd + "/" + projectName
 
 	ishell.PurrgilAlert("Init a new Purrgil App into: " + projectName)
 
-	if (projectGithub == "") {
+	if (opts.Provider == "") {
 		os.Mkdir(projectName, 0777)
 	} else {
-		GitClone(projectGithub, projectName)
+		RunDownloadFromProvider(file.PurrgilPackage{
+			Identity: opts.Repo,
+			Name: projectName,
+			SSH: opts.IsSSH,
+			Provider: opts.Provider,
+		})
 	}
 
 	dockercompose := file.NewDockerCompose(wdpath)

--- a/commands/install.go
+++ b/commands/install.go
@@ -3,9 +3,32 @@ package commands
 import (
 	"os"
 	"os/exec"
+	"strings"
+	"fmt"
+	"errors"
 
 	"github.com/purrgil/purrgil/file"
 	"github.com/purrgil/purrgil/interactiveshell"
+)
+
+type ProviderMap struct {
+	ssh string
+	https string
+}
+
+var (
+	githubProvider = ProviderMap{
+		ssh: "git@github.com:%s.git",
+		https: "https://github.com/%s.git",
+	}
+	bitbucketProvider = ProviderMap{
+		ssh: "git@bitbucket.org:%s.git",
+		https: "https://%s@bitbucket.org/%s.git",
+	}
+	bitbucketMcrProvider = ProviderMap{
+		ssh: "ssh://hg@bitbucket.org/%s",
+		https: "https://%s@bitbucket.org/%s",
+	}
 )
 
 func Install() {
@@ -23,18 +46,61 @@ func Install() {
 func PackageInstall(pkg file.PurrgilPackage) {
 	ishell.PurrgilAlert("Installing " + pkg.Name + " package...")
 
-	if pkg.Provider == "github" {
-		GitClone(pkg.Identity, pkg.Name)
-	} else {
-		DockerPull(pkg.Identity)
-	}
+	RunDownloadFromProvider(pkg)
 
 	ishell.PurrgilAlert(pkg.Name + " was successfuly installed")
 }
 
-func GitClone(repo string, folderName string) {
-	ssh := "git@github.com:" + repo + ".git"
-	cmd := exec.Command("git", "clone", ssh, folderName)
+func RunDownloadFromProvider(pkg file.PurrgilPackage) {
+	switch pkg.Provider {
+	case "github":
+		GithubClone(pkg, githubProvider)
+	case "bitbucket":
+		BitbucketClone("git", pkg, bitbucketProvider)
+	case "bitbucket_mcr":
+		BitbucketClone("hg", pkg, bitbucketMcrProvider)
+	case "dockerhub":
+		DockerPull(pkg.Identity)
+	default:
+		notFoundProvider := "We not found this repo! Try: github, bitbucket, dockerhub or bitbucket_mcr (support mercurial)"
+		ishell.Err(notFoundProvider, errors.New(notFoundProvider))
+	}
+}
+
+func GithubClone(pkg file.PurrgilPackage, kind ProviderMap) {
+	var template string
+
+	if !pkg.SSH {
+		template = fmt.Sprintf(kind.https, pkg.Identity)
+	} else {
+		template = fmt.Sprintf(kind.ssh, pkg.Identity)
+	}
+
+	println(template)
+	RepoClone("git", template, pkg.Name)
+}
+
+func BitbucketClone(providerCommand string, pkg file.PurrgilPackage, kind ProviderMap) {
+	var template string
+
+	if !pkg.SSH {
+		user, repoId := getBitBucketParms(pkg.Identity)
+		template = fmt.Sprintf(kind.https, user, repoId)
+	} else {
+		template = fmt.Sprintf(kind.ssh, pkg.Identity)
+	}
+
+
+	RepoClone(providerCommand, template, pkg.Name)
+}
+
+func getBitBucketParms(id string) (string, string) {
+	splited := strings.Split(id, ":")
+	return splited[0], splited[1]
+}
+
+func RepoClone(providerCmd string, repo string, folderName string) {
+	cmd := exec.Command(providerCmd, "clone", repo , folderName)
 	err := cmd.Run()
 
 	if err != nil {

--- a/commands/pkglist.go
+++ b/commands/pkglist.go
@@ -2,10 +2,13 @@ package commands
 
 import (
 	"fmt"
+	"regexp"
+	"errors"
+	"os"
+	"strconv"
 	"github.com/purrgil/purrgil/configs"
 	"github.com/purrgil/purrgil/file"
 	"github.com/purrgil/purrgil/interactiveshell"
-	"os"
 )
 
 func PackageList(opts configs.CommandPackageConfig) {
@@ -15,47 +18,60 @@ func PackageList(opts configs.CommandPackageConfig) {
 
 	ishell.PurrgilAlert("Listing packages from " + purrgilconfig.Name + "...")
 
-	// if opts.IsGithub && !opts.IsDockerhub {
-	// 	mypackages = file.PurrgilGetPackages(mypackages, filterGithub)
-	// } else if !opts.IsGithub && opts.IsDockerhub {
-	// 	mypackages = file.PurrgilGetPackages(mypackages, filterDockerhub)
-	// }
+	for k, v := range opts.FilterSettings {
+		if hasKey(file.PurrgilAvaibleFilters, k) {
+			mypackages = file.PurrgilGetPackages(mypackages, func(pkg file.PurrgilPackage) bool {
+				var val string
 
-	// if opts.IsService && !opts.IsNormal {
-	// 	mypackages = file.PurrgilGetPackages(mypackages, filterService)
-	// } else if !opts.IsService && opts.IsNormal {
-	// 	mypackages = file.PurrgilGetPackages(mypackages, filterNonservice)
-	// }
+				switch k {
+				case "name":
+					val = pkg.Name
+				case "identity":
+					val = pkg.Identity
+				case "service":
+					val = strconv.FormatBool(pkg.Service)
+				case "ssh":
+					val = strconv.FormatBool(pkg.SSH)
+				case "provider":
+					val = pkg.Provider
+				}
+
+				m, err := regexp.MatchString(v, val)
+
+				if err != nil {
+					regError := "Error in regex"
+					ishell.Err(regError, errors.New(regError))
+				}
+
+				return m
+			})
+		}
+	}
 
 	if len(mypackages) == 0 {
 		ishell.PurrgilAlert("Not found packages from this filters :(")
 	}
 
 	for _, value := range mypackages {
-		fmt.Printf("  - %s <- %s \n", value.Name, value.Identity)
+		var template string
+
+		if value.Provider != "dockerhub" {
+			template = "Package: %s into [./%s] from %s  \n"
+		} else {
+			template = "Package: %s image named as %s on %s \n"
+		}
+
+		formatedString := fmt.Sprintf(template, value.Identity, value.Name, value.Provider)
+		ishell.PurrgilAlert(formatedString)
 	}
 }
 
-func filterGithub(pkg file.PurrgilPackage) bool {
-	if pkg.Provider == "github" {
-		return true
+func hasKey(list []string, k string) bool {
+	for _, v := range list {
+		if v == k {
+			return true
+		}
 	}
 
 	return false
-}
-
-func filterService(pkg file.PurrgilPackage) bool {
-	if pkg.Service {
-		return true
-	}
-
-	return false
-}
-
-func filterDockerhub(pkg file.PurrgilPackage) bool {
-	return !filterGithub(pkg)
-}
-
-func filterNonservice(pkg file.PurrgilPackage) bool {
-	return !filterService(pkg)
 }

--- a/commands/pkglist.go
+++ b/commands/pkglist.go
@@ -15,17 +15,17 @@ func PackageList(opts configs.CommandPackageConfig) {
 
 	ishell.PurrgilAlert("Listing packages from " + purrgilconfig.Name + "...")
 
-	if opts.IsGithub && !opts.IsDockerhub {
-		mypackages = file.PurrgilGetPackages(mypackages, filterGithub)
-	} else if !opts.IsGithub && opts.IsDockerhub {
-		mypackages = file.PurrgilGetPackages(mypackages, filterDockerhub)
-	}
+	// if opts.IsGithub && !opts.IsDockerhub {
+	// 	mypackages = file.PurrgilGetPackages(mypackages, filterGithub)
+	// } else if !opts.IsGithub && opts.IsDockerhub {
+	// 	mypackages = file.PurrgilGetPackages(mypackages, filterDockerhub)
+	// }
 
-	if opts.IsService && !opts.IsNormal {
-		mypackages = file.PurrgilGetPackages(mypackages, filterService)
-	} else if !opts.IsService && opts.IsNormal {
-		mypackages = file.PurrgilGetPackages(mypackages, filterNonservice)
-	}
+	// if opts.IsService && !opts.IsNormal {
+	// 	mypackages = file.PurrgilGetPackages(mypackages, filterService)
+	// } else if !opts.IsService && opts.IsNormal {
+	// 	mypackages = file.PurrgilGetPackages(mypackages, filterNonservice)
+	// }
 
 	if len(mypackages) == 0 {
 		ishell.PurrgilAlert("Not found packages from this filters :(")

--- a/configs/commands.go
+++ b/configs/commands.go
@@ -2,14 +2,18 @@ package configs
 
 type AddConfig struct {
 	IsService  bool
-	Dockerhub  bool
+	Provider  string
+	HttpsMode bool
 	CustomName string
 	ComposeConfig bool
 }
 
 type CommandPackageConfig struct {
-	IsGithub    bool
-	IsDockerhub bool
-	IsService   bool
-	IsNormal    bool
+	FilterSettings map[string]string
+}
+
+type InitConfig struct {
+	IsSSH  bool
+	Repo  string
+	Provider string
 }

--- a/file/purrgilpkg.go
+++ b/file/purrgilpkg.go
@@ -10,6 +10,7 @@ type PurrgilPackage struct {
 	Identity string `yaml:"identity"`
 	Provider string `yaml:"provider"`
 	Service  bool   `yaml:"service"`
+	SSH bool `yarml:"ssh"`
 }
 
 func NewPurrgilPackage(id string, opts configs.AddConfig) PurrgilPackage {
@@ -17,8 +18,9 @@ func NewPurrgilPackage(id string, opts configs.AddConfig) PurrgilPackage {
 
 	pkg.Identity = id
 	pkg.Name = normalizeName(id, opts.CustomName)
-	pkg.Provider = getProvider(opts.Dockerhub)
+	pkg.Provider = getProvider(opts.Provider)
 	pkg.Service = !opts.IsService
+	pkg.SSH = !opts.HttpsMode
 
 	return pkg
 }
@@ -38,10 +40,10 @@ func normalizeName(id string, custom string) string {
 	return id
 }
 
-func getProvider(isDockerhub bool) string {
-	if isDockerhub {
-		return "dockerhub"
+func getProvider(provider string) string {
+	if provider == "" {
+		return "github"
 	}
 
-	return "github"
+	return provider
 }

--- a/file/purrgilpkg.go
+++ b/file/purrgilpkg.go
@@ -13,6 +13,14 @@ type PurrgilPackage struct {
 	SSH bool `yarml:"ssh"`
 }
 
+var PurrgilAvaibleFilters = []string {
+	"name",
+	"identity",
+	"provider",
+	"service",
+	"ssh",
+}
+
 func NewPurrgilPackage(id string, opts configs.AddConfig) PurrgilPackage {
 	pkg := PurrgilPackage{}
 


### PR DESCRIPTION
### Issue
this resolve #12 

### Description
Change commands to receive generic providers

### Changelog (not mandatory but enconraged)
- Now **ADD** lost `--dockerhub` flag and receive a `--provider <providerName>`
- Add compatibility with mercurial and bitbucket things

### Topics (optional)
- Change in variable names

### Any photo of a cute animal or a beautiful place! (not mandatory but enconraged)
![caxorrineo](https://scontent.frao1-1.fna.fbcdn.net/v/t1.0-9/12141666_10204413383165874_7155243149054486914_n.jpg?oh=5cd914402880c579a87eb445382fb704&oe=591B93E2)